### PR TITLE
fix: improve CLI output path resolution and error reporting

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -54,11 +54,14 @@ type CliOptions = {
 const OVERLAY_EXTENSIONS = ['.mjs', '.js', '.cjs', '.ts'] as const;
 
 function resolveOutputPath(options: CliOptions): string {
-    const outputPath: string = options.output ? String(options.output) : '';
-    if (outputPath) {
-        const ext = path.extname(outputPath).toLowerCase();
-        if (ext === '.pdf') return outputPath;
+    if (options.output) {
+        const ext = path.extname(options.output).toLowerCase();
+        if (ext === '.pdf') return options.output;
         throw new Error(`Unsupported output extension "${ext || '(none)'}". Use .pdf.`);
+    }
+    if (options.input) {
+        const parsed = path.parse(options.input);
+        return path.format({ ...parsed, base: undefined, ext: '.pdf' });
     }
     return 'output.pdf';
 }
@@ -268,6 +271,6 @@ async function run() {
 }
 
 run().catch((error) => {
-    console.error('[vmprint] Failed:', error);
+    console.error(`[vmprint] Failed: ${error.message || error}`);
     process.exit(1);
 });


### PR DESCRIPTION
Improved the CLI's output file resolution to automatically derive the output filename from the input file if no output path is explicitly provided, enhancing usability and matching standard CLI conventions. Also refined the global error handling in the CLI entry point to display cleaner, user-focused error messages by logging only the error message instead of the full stack trace, ensuring a more professional and less cluttered output on failure. Closes #1